### PR TITLE
added dockerfile and run test script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# Use same distribution as Travis.CI
+FROM ubuntu:12.04
+
+# Install all dependencies to build hxcpp, haxe and neko
+RUN apt-get update
+RUN apt-get install -y \
+                         git \
+                         sudo \
+                         build-essential \
+                         libpcre3-dev \
+                         ocaml-native-compilers \
+                         zlib1g-dev \
+                         libgc-dev \
+                         gcc-multilib \
+                         g++-multilib
+
+# Build neko
+RUN git clone https://github.com/HaxeFoundation/neko.git /neko
+WORKDIR /neko
+RUN make
+RUN sudo make install
+
+# Build haxe
+RUN git clone --recursive https://github.com/HaxeFoundation/haxe.git /haxe
+WORKDIR /haxe
+RUN make OCAMLOPT=ocamlopt.opt ADD_REVISION=1
+RUN make tools
+RUN make install
+
+# Mount point for hxcpp code
+VOLUME /hxcpp
+
+# Setup haxelib with hxcpp
+RUN mkdir /haxelib
+WORKDIR /haxelib
+RUN haxelib setup .
+RUN haxelib dev hxcpp /hxcpp
+
+# Add env needed by hxcpp test script
+ENV BUILD_DIR /hxcpp
+ENV HAXE_DIR /haxe
+
+# Run hxcpp tests when container starts
+WORKDIR /hxcpp
+CMD ./run_tests.sh
+

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+cd ${BUILD_DIR}/tools/run
+haxe compile.hxml
+
+cd ${BUILD_DIR}/tools/hxcpp
+haxe compile.hxml
+cd ${BUILD_DIR}/project
+neko build.n -verbose
+haxe compile-cppia.hxml
+
+cd ${BUILD_DIR}/test
+haxe --run RunTests
+
+cd ${HAXE_DIR}/tests/unit
+haxe compile-cpp.hxml -D HXCPP_M32 && ./bin/cpp/Test-debug && rm -rf bin/cpp
+haxe compile-cpp.hxml -D HXCPP_M64 && ./bin/cpp/Test-debug
+haxe compile-cppia.hxml -debug && haxelib run hxcpp unit.cppia


### PR DESCRIPTION
I wanted to try another use-case with Docker. This allows me to run the tests in an env similar to Travis.ci.

If you want to give it a try, run the following commands from your repo:

```
docker build -t hxcpp .
```

This creates an image named `hxcpp` from the Dockerfile.

```
docker run -v ${PWD}:/hxcpp -t hxcpp
```

This starts a container which test the code mounted with the `-v` option
