### PR TITLE
use OBJDIR from env to configure .o output dir

### DIFF
--- a/toolchain/finish-setup.xml
+++ b/toolchain/finish-setup.xml
@@ -59,6 +59,8 @@
 <set name="DESTDIR" value="lib" if="static_link" unless="HXCPP_IOS_STDCPP"/>
 <set name="NDLLDIR" value="ndll" />
 <set name="NDLLDIR" value="lib" if="static_link" />
+<set name="BUILDDIR" value="obj" unless="BUILDDIR" />
+<set name="BUILDDIR" value="${BUILDDIR}" if="BUILDDIR" />
 
 
 <set name="IPHONE_VER" value="4.2" unless="IPHONE_VER" />

--- a/toolchain/linux-toolchain.xml
+++ b/toolchain/linux-toolchain.xml
@@ -50,7 +50,7 @@
   <flag value="-m64" if="HXCPP_M64"/>
   <flag value="-DHXCPP_M64" if="HXCPP_M64"/>
   <flag value="-I${HXCPP}/include"/>
-  <objdir value="obj/linux${OBJEXT}/"/>
+  <objdir value="${BUILDDIR}/linux${OBJEXT}/"/>
   <outflag value="-o"/>
   <ext value=".o"/>
 </compiler>

--- a/toolchain/mac-toolchain.xml
+++ b/toolchain/mac-toolchain.xml
@@ -32,7 +32,7 @@
   <flag value="-Wno-bool-conversion" if="HXCPP_CLANG"/>
   <flag value="-fobjc-arc" if="OBJC_ARC" />
   <include name="toolchain/common-defines.xml" />
-  <objdir value="obj/darwin${OBJEXT}/" />
+  <objdir value="${BUILDDIR}/darwin${OBJEXT}/" />
   <outflag value="-o"/>
   <ext value=".o"/>
   <getversion value="xcrun --sdk macosx${MACOSX_VER} clang++ -v" if="HXCPP_CLANG" />


### PR DESCRIPTION
@bjitivo,
I just use the `OBJDIR` for linux and mac toolchain. If Haxe Foundation accepts this change, I'll ask if I should apply it to all toolchains.
I don't do it right away because there seems to be slight difference in how the output is generated for other targets such as Android or BlackBerry
